### PR TITLE
Update postinstall.sh

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=$(node --eval "console.log(require('./node_modules/electron-prebuilt/package.json').version);")
+VERSION=$(node --eval "console.log(require('./node_modules/electron/package.json').version);")
 
 cd node_modules/leveldown
 HOME=~/.electron-gyp


### PR DESCRIPTION
Electron no longer saves as `electron-prebuilt` under `node_modules`. Changed the path to: `./node_modules/electron/package.json`.
