### PR TITLE
replace electron-rebuild with electron-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 mydb-*
 _pouch_mydb-sqlite
+dist

--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@ And run:
 
     npm start
 
+Build:
+
+    npm run build
+
 If it doesn't work, you might not have the latest version of Node/npm. Try installing the latest using [nvm](https://github.com/creationix/nvm).
 
 ## Browser vs Node
 
-In order to get LevelDB to work propertly, we use [electron-rebuild](https://github.com/electron/electron-rebuild) to rebuild LevelDB for Electron.
+To build the application we use [electron-builder](https://github.com/electron-userland/electron-builder). You'll be able to build the app for macOS/Linux/Windows, but it must be compiled on the target platform. 
+
+In order to get the native dependencies (LevelDB and sqlite3) to work properly with the Electron version, we include the script `"postinstall": "electron-builder install-app-deps"`.
 
 If this step doesn't work for you (e.g. because you are using an older version of Node, you're using Windows, etc.), you can remove the `postinstall` script from `package.json`, replace the `pouchdb` dependency with `pouchdb-browser`, and just use the browser adapters (IndexedDB/WebSQL) rather than the Node.js adapter (LevelDB).
 

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "postinstall": "electron-rebuild"
+    "build": "electron-builder build",
+    "postinstall": "electron-builder install-app-deps"
   },
   "devDependencies": {
-    "electron": "^1.4.12",
-    "electron-rebuild": "^1.4.0"
+    "electron": "^3.0.0",
+    "electron-builder": "^20.38.3"
   },
   "dependencies": {
-    "pouchdb": "^6.1.0",
-    "pouchdb-adapter-node-websql": "^6.1.0"
+    "pouchdb": "^7.0.0",
+    "pouchdb-adapter-node-websql": "^7.0.0",
+    "pouchdb-adapter-websql": "^7.0.0"
   }
 }

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ db.info().then(function (info) {
 
 // WebSQL
 
+PouchDB.plugin(require('pouchdb-adapter-websql'));
 var websqlDB = new PouchDB('mydb-websql', {adapter: 'websql'});
 
 websqlDB.info().then(function (info) {
@@ -24,11 +25,19 @@ websqlDB.info().then(function (info) {
   $('#websql').innerHTML = 'Error for WebSQL';
 });
 
+// File paths for LevelDB and node-websql
+
+var {remote} = require('electron');
+var path = require('path');
+
+var leveldbPath = path.join(remote.app.getPath('userData'), 'mydb-leveldb');
+var sqlitePath = path.join(remote.app.getPath('userData'), 'mydb-sqlite');
+
 // LevelDB
 
 var NodePouchDB = require('pouchdb');
 
-var leveldbDB = new NodePouchDB('mydb-leveldb');
+var leveldbDB = new NodePouchDB(leveldbPath);
 
 leveldbDB.info().then(function (info) {
   $('#leveldb').innerHTML = '&#10004; We can use PouchDB with LevelDB!';
@@ -39,7 +48,7 @@ leveldbDB.info().then(function (info) {
 // node-websql
 
 NodePouchDB.plugin(require('pouchdb-adapter-node-websql'));
-var sqliteDB = new NodePouchDB('mydb-sqlite', {adapter: 'websql'});
+var sqliteDB = new NodePouchDB(sqlitePath, {adapter: 'websql'});
 
 sqliteDB.info().then(function (info) {
   $('#sqlitedb').innerHTML = '&#10004; We can use PouchDB with node-websql (SQLite)!';


### PR DESCRIPTION
This PR is to revive this repo by replacing electron-rebuild with [electron-builder](https://www.electron.build/).  Among many features electron-builder handles native dependencies well.

I was able to compile the app for Windows and macOS.  IndexedDB, WebSQL, LevelDB, and node-websql (SQLite) all working.

When running the app with `npm start` the LevelDB folder and sqlite file were stored in the project directory which is fine, but when compiled i'm not quite sure where they were stored or if it was being stored at all.  

I found out that if you add a file path to the PouchDB constructor it will store the databases in that location.  I can't find any mention of this being part of the PouchDB API, but its working. 

